### PR TITLE
Enable symlinks in zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Zip artifact
         working-directory: opencv
-        run: zip -r opencv2.xcframework.zip build/opencv2.xcframework
+        run: zip -ry opencv2.xcframework.zip build/opencv2.xcframework
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The framework structure contains symbolic link. `zip -r` copies them by default. As described in [zip(1)](https://linux.die.net/man/1/zip), the archive size can be reduced with symlinks enabled.

```
-y
--symlinks
       For UNIX and VMS (V8.3 and later), store symbolic links as such in the zip archive,
       instead of compressing and storing the file referred to by the link.  This can avoid
       multiple copies of files being included in the archive as zip recurses the directory
       trees and accesses files directly and by links.
```

In my case, the size is 454M -> 151M.