### PR TITLE
Aj sc 389979 us gc artifact actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: zip -ry opencv2.xcframework.zip build/opencv2.xcframework
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: gamechanger/upload-artifact-action@v1
         with:
           name: opencv2.xcframework.zip
           path: opencv/opencv2.xcframework.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Build and release a new version
-
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
 on:
   push:
     branches: [ "main" ]
@@ -41,8 +44,6 @@ jobs:
           sed -i "s/let checksum = \".*\"/let checksum = \"$(shasum -a 256 opencv2.xcframework.zip | cut -d ' ' -f 1)\"/" Package.swift
 
       - name: Commit and push
-        env:
-          ACCESS_TOKEN: '${{ secrets.ACCESS_TOKEN }}'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "GitHub Actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ permissions:
   pull-requests: write
   issues: write
   repository-projects: write
+  contents: write
+  packages: write
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
           sed -i "s/let checksum = \".*\"/let checksum = \"$(shasum -a 256 opencv2.xcframework.zip | cut -d ' ' -f 1)\"/" Package.swift
 
       - name: Commit and push
+        env:
+          ACCESS_TOKEN: '${{ secrets.ACCESS_TOKEN }}'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "GitHub Actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,13 @@ jobs:
           sed -i "s/let version = \".*\"/let version = \"${{ steps.get_version.outputs.VERSION }}\"/" Package.swift
           sed -i "s/let checksum = \".*\"/let checksum = \"$(shasum -a 256 opencv2.xcframework.zip | cut -d ' ' -f 1)\"/" Package.swift
 
-      - name: Commit and push
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "GitHub Actions"
-          git add Package.swift
-          git commit -m "Update Package.swift"
-          git push
+      # - name: Commit and push
+      #   run: |
+      #     git config --local user.email "github-actions[bot]@users.noreply.github.com"
+      #     git config --local user.name "GitHub Actions"
+      #     git add Package.swift
+      #     git commit -m "Update Package.swift"
+      #     git push
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.PUSH_TO_OPENCV_SPM }}
       
       - name: Fetch OpenCV latest version
         run: |

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let version = "4.8.0+14"
-let checksum = "6683cac108e7302b73b04f16e6fb631ff7eb17f17e6d2398564e9bbe774068eb"
+let checksum = "83d60791fb49b22a9c587d6aded426d213afcfc733a5439b050e5dddd2706292"
 
 let package = Package(
     name: "OpenCV",

--- a/Package.swift
+++ b/Package.swift
@@ -7,13 +7,13 @@ let version = "4.8.0+14"
 let checksum = "83d60791fb49b22a9c587d6aded426d213afcfc733a5439b050e5dddd2706292"
 
 let package = Package(
-    name: "OpenCV",
+    name: "opencv2",
     platforms: [
         .macOS(.v10_13), .iOS(.v11), .macCatalyst(.v13)
     ],
     products: [
         .library(
-            name: "OpenCV",
+            name: "opencv2",
             targets: ["opencv2", "opencv2-dependencies"]),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 
 import PackageDescription
 
-let version = "4.8.0+14"
+let version = "4.8.0"
 let checksum = "83d60791fb49b22a9c587d6aded426d213afcfc733a5439b050e5dddd2706292"
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let version = "4.8.0"
 let checksum = "83d60791fb49b22a9c587d6aded426d213afcfc733a5439b050e5dddd2706292"
 
 let package = Package(
-    name: "opencv2",
+    name: "opencv-spm",
     platforms: [
         .macOS(.v10_13), .iOS(.v11), .macCatalyst(.v13)
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 
 import PackageDescription
 
-let version = "4.8.0"
+let version = "4.8.0+14"
 let checksum = "6683cac108e7302b73b04f16e6fb631ff7eb17f17e6d2398564e9bbe774068eb"
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 
 import PackageDescription
 
-let version = "4.8.0+13"
-let checksum = "83d60791fb49b22a9c587d6aded426d213afcfc733a5439b050e5dddd2706292"
+let version = "4.8.0"
+let checksum = "6683cac108e7302b73b04f16e6fb631ff7eb17f17e6d2398564e9bbe774068eb"
 
 let package = Package(
     name: "OpenCV",
@@ -18,7 +18,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "opencv2",
-                      url: "https://github.com/yeatse/opencv-spm/releases/download/\(version)/opencv2.xcframework.zip",
+                      url: "https://github.com/gamechanger/opencv-spm/releases/download/\(version)/opencv2.xcframework.zip",
                       checksum: checksum),
         .target(
             name: "opencv2-dependencies",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Swift package simplifies the process of importing the prebuilt `opencv2.xcf
 
 ## Installation
 
-Add `https://github.com/yeatse/opencv-spm.git` to your package dependencies
+Add `https://github.com/gamechanger/opencv-spm.git` to your package dependencies
 
 ![add dependency](screenshots/add%20dependency.png)
 


### PR DESCRIPTION
Use GC artifact action wrapper. 
Per infosec, all third party actions need to be pinned to a specific SHA. 
This now uses a GC wrapper that pins to the specific SHA of the third party so we can use main versions in calling repos like opencv-spm.